### PR TITLE
UpdateRecipient will find recipient now; Added support for the (new?) RawRecipientDataExport call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_STORE

--- a/lib/engage-xml-api.js
+++ b/lib/engage-xml-api.js
@@ -40,7 +40,6 @@ var EngageXmlApi = function(engage, engageAuth) {
     function _buildXmlApiMethod(methodName, optionsTemplate, generator, resultTemplate) {
 
         var properMethodName = methodName.charAt(0).toUpperCase() + methodName.slice(1);
-
         if (_engage.getDebugLevel() >= 4) {
             console.log('building XML API method ' + methodName);
         }
@@ -166,4 +165,3 @@ var EngageXmlApi = function(engage, engageAuth) {
 };
 
 module.exports = EngageXmlApi;
-

--- a/lib/xml-api/export-list.js
+++ b/lib/xml-api/export-list.js
@@ -45,8 +45,27 @@ module.exports = {
         var params = {
             "LIST_ID": options.listId,
             "EXPORT_TYPE": options.exportType,
-            "EXPORT_FORMAT": options.exportFormat
+            "EXPORT_FORMAT": options.exportFormat,
+            "DATE_START": options.dateStart,
+            "DATE_END": options.dateEnd,
+            "EXPORT_COLUMNS": options.exportColumns,
         };
+
+        if (typeof options.listId !== 'undefined') {
+            params["LIST_ID"] = options.listId;
+        }
+
+        if (typeof options.exportType !== 'undefined') {
+            params["EXPORT_TYPE"] = options.exportType;
+        }
+
+        if (typeof options.exportFormat !== 'undefined') {
+            params["EXPORT_FORMAT"] = options.exportFormat;
+        }
+
+        if (typeof options.listId !== 'undefined') {
+            params["LIST_ID"] = options.listId;
+        }
 
         if (typeof options.dateStart !== 'undefined') {
             params["DATE_START"] = options.dateStart;
@@ -76,4 +95,3 @@ module.exports = {
         }
     }
 };
-

--- a/lib/xml-api/get-sent-mailings-for-org.js
+++ b/lib/xml-api/get-sent-mailings-for-org.js
@@ -1,0 +1,115 @@
+const Engage = require( __dirname + '/../engage-constants' );
+const validator = require( __dirname + '/../validator' );
+
+module.exports = {
+
+  options: {
+
+    dateStart: {
+      required: true,
+      assert: validator.coerceString,
+    },
+    dateEnd: {
+      required: true,
+      assert: validator.coerceString,
+    },
+    scheduled: {
+      required: false,
+      assert: validator.coerceBoolean,
+    },
+    sent: {
+      required: false,
+      assert: validator.coerceBoolean,
+    },
+    sending: {
+      required: false,
+      assert: validator.coerceBoolean,
+    },
+    includeTags: {
+      required: false,
+      assert: validator.coerceBoolean,
+    },
+    excludeZeroSent: {
+      required: false,
+      assert: validator.coerceBoolean,
+    },
+    excludeTestMailings: {
+      required: false,
+      assert: validator.coerceBoolean,
+    }
+  },
+  generator: function( options ) {
+    var subnode, key;
+
+    const params = {
+      'DATE_START': options.dateStart,
+      'DATE_END': options.dateEnd,
+      'SCHEDULED': options.scheduled,
+      'SENT': options.sent,
+      'SENDING': options.sending,
+      'INCLUDE_TAGS': options.includeTags,
+      'EXCLUDE_ZERO_SENT': options.excludeZeroSent,
+      'EXCLUDE_TEST_MAILINGS': options.excludeTestMailings,
+    };
+
+    if ( typeof options.dateStart !== 'undefined' ) {
+      params[ 'DATE_START' ] = options.dateStart;
+    }
+
+    if ( typeof options.dateEnd !== 'undefined' ) {
+      params[ 'DATE_END' ] = options.dateEnd;
+    }
+
+    if ( typeof options.scheduled !== 'undefined' ) {
+      params[ 'SCHEDULED' ] = options.scheduled;
+    }
+
+    if ( typeof options.sent !== 'undefined' ) {
+      params[ 'SENT' ] = options.sent;
+    }
+
+    if ( typeof options.sending !== 'undefined' ) {
+      params[ 'SENDING' ] = options.sending;
+    }
+
+    if ( typeof options.includeTags !== 'undefined' ) {
+      params[ 'INCLUDE_TAGS' ] = options.includeTags;
+    }
+
+    if ( typeof options.excludeZeroSent !== 'undefined' ) {
+      params[ 'EXCLUDE_ZERO_SENT' ] = options.excludeZeroSent;
+    }
+
+    if ( typeof options.excludeTestMailings !== 'undefined' ) {
+      params[ 'EXCLUDE_TEST_MAILINGS' ] = options.excludeTestMailings;
+    }
+
+    return params;
+  },
+
+  result: {
+    'Mailing': {
+      rename: 'mailing',
+      required: true,
+      multi: true,
+      assert: {
+        'MailingId': {
+          rename: 'mailingid',
+          required: true,
+          assert: validator.coerceInteger,
+        },
+        'Tags': {
+          rename: 'tags',
+          required: true,
+          assert: {
+            'Tag': {
+              rename: 'tag',
+              required: true,
+              assert: validator.coerceScalarHash,
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/lib/xml-api/get-sent-mailings-for-org.js
+++ b/lib/xml-api/get-sent-mailings-for-org.js
@@ -104,7 +104,7 @@ module.exports = {
           assert: {
             'Tag': {
               rename: 'tag',
-              required: true,
+              required: false,
               assert: validator.coerceScalarHash,
             }
           }

--- a/lib/xml-api/import-list.js
+++ b/lib/xml-api/import-list.js
@@ -1,0 +1,38 @@
+var Engage = require( __dirname + '/../engage-constants' );
+var validator = require( __dirname + '/../validator' );
+
+module.exports = {
+  options: {
+    mapFile: {
+        required: true,
+        assert: validator.assertString,
+    },
+    sourceFile: {
+        required: true,
+        assert: validator.assertString,
+    },
+    email: {
+        required: false,
+        assert: validator.assertString,
+    },
+    fileEncoding: {
+        required: false,
+        assert: validator.assertString,
+    },
+  },
+  generator: function( options ) {
+    return {
+        "MAP_FILE": options.mapFile,
+        "SOURCE_FILE": options.sourceFile,
+        "EMAIL": options.email,
+        "FILE_ENCODING": options.fielEncoding,
+    };
+  },
+  result: {
+    "JOB_ID": {
+        rename: "jobId",
+        required: true,
+        assert: validator.coercePositiveInteger
+    },
+  },
+};

--- a/lib/xml-api/raw-recipient-data-export.js
+++ b/lib/xml-api/raw-recipient-data-export.js
@@ -179,31 +179,31 @@ module.exports = {
             params["EVENT_DATE_END"] = options.eventDateEnd;
         }
 
-         return params;
-     },
+        return params;
+    },
 
     result: {
-       "MAILING": {
-         rename: "mailing",
-         required: true,
-         assert: function(val, name) {
-             var objVal = JSON.parse(JSON.stringify(val));
-             var subVal = validator.validateObject({
-                  "JOB_ID": {
-                   rename: "jobId",
-                   required: true,
-                   assert: validator.coerceString
-                  },
-                  "FILE_PATH": {
-                    rename:"filePath",
-                    required:true,
-                    assert: validator.coerceString
-                  },
-              default: []
-             }, objVal);
+     "MAILING": {
+       rename: "mailing",
+       required: true,
+       assert: function(val, name) {
+           var objVal = JSON.parse(JSON.stringify(val));
+           var subVal = validator.validateObject({
+              "JOB_ID": {
+                 rename: "jobId",
+                 required: true,
+                 assert: validator.coerceString
+             },
+             "FILE_PATH": {
+                rename:"filePath",
+                required:true,
+                assert: validator.coerceString
+            },
+            default: []
+        }, objVal);
 
-             return subVal;
-         }
+           return subVal;
        }
-    }
+   }
+}
 };

--- a/lib/xml-api/raw-recipient-data-export.js
+++ b/lib/xml-api/raw-recipient-data-export.js
@@ -1,0 +1,149 @@
+var Engage = require(__dirname + '/../engage-constants');
+var validator = require(__dirname + '/../validator');
+
+module.exports = {
+
+    options: {
+
+        listId: {
+            required: true,
+            assert: validator.coercePositiveInteger
+        },
+
+        includeChildren: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        },
+
+        exportFileName: {
+            required: false,
+            assert: validator.assertString
+        },
+
+        email: {
+            required: false,
+            assert: validator.assertString
+        },
+
+        moveToFtp: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        },
+
+        allEventTypes: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        },
+
+        opens: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        },
+
+        clicks: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        },
+
+        optIns: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        },
+
+        optOuts: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false
+        }
+
+    },
+
+    generator: function(options) {
+        var subnode, key;
+
+        var params = {
+            "LIST_ID": options.listId,
+            "INCLUDE_CHILDREN": options.includeChildren,
+            "EXPORT_FILE_NAME": options.exportFileName,
+            "EMAIL": options.email,
+            "MOVE_TO_FTP": options.moveToFtp,
+            "ALL_EVENT_TYPES": options.allEventTypes,
+            "OPENS": options.opens,
+            "CLICKS": options.clicks,
+            "OPTINS": options.optIns,
+            "OPTOUTS": options.optOuts
+        };
+
+        if (typeof options.listId !== 'undefined') {
+            params["LIST_ID"] = options.listId;
+        }
+
+        if (typeof options.includeChildren !== 'undefined') {
+            params["INCLUDE_CHILDREN"] = options.includeChildren;
+        }
+
+        if (typeof options.exportFileName !== 'undefined') {
+            params["EXPORT_FILE_NAME"] = options.exportFileName;
+        }
+
+        if (typeof options.email !== 'undefined') {
+            params["EMAIL"] = options.email;
+        }
+
+        if (typeof options.moveToFtp !== 'undefined') {
+            params["MOVE_TO_FTP"] = options.moveToFtp;
+        }
+
+        if (typeof options.allEventTypes !== 'undefined') {
+            params["ALL_EVENT_TYPES"] = options.allEventTypes;
+        }
+
+        if (typeof options.opens !== 'undefined') {
+            params["OPENS"] = options.opens;
+        }
+
+        if (typeof options.clicks !== 'undefined') {
+            params["CLICKS"] = options.clicks;
+        }
+
+        if (typeof options.optIns !== 'undefined') {
+            params["OPTINS"] = options.optIns;
+        }
+
+        if (typeof options.optOuts !== 'undefined') {
+            params["OPTOUTS"] = options.optOuts;
+        }
+         return params;
+     },
+
+    result: {
+       "MAILING": {
+         rename: "mailing",
+         required: true,
+         assert: function(val, name) {
+             var objVal = JSON.parse(JSON.stringify(val));
+             var subVal = validator.validateObject({
+                  "JOB_ID": {
+                   rename: "jobId",
+                   required: true,
+                   assert: validator.coerceString
+                  },
+                  "FILE_PATH": {
+                    rename:"filePath",
+                    required:true,
+                    assert: validator.coerceString
+                  },
+              default: []
+             }, objVal);
+
+             return subVal;
+         }
+       }
+    }
+};

--- a/lib/xml-api/raw-recipient-data-export.js
+++ b/lib/xml-api/raw-recipient-data-export.js
@@ -26,6 +26,26 @@ module.exports = {
             assert: validator.assertString
         },
 
+        eventDateStart: {
+            required: false,
+            assert: validator.assertString
+        },
+
+        eventDateEnd: {
+            required: false,
+            assert: validator.assertString
+        },
+
+        sendDateStart: {
+            required: false,
+            assert: validator.assertString
+        },
+
+        sendDateEnd: {
+            required: false,
+            assert: validator.assertString
+        },
+
         moveToFtp: {
             required: false,
             assert: validator.assertBoolean,
@@ -77,7 +97,11 @@ module.exports = {
             "OPENS": options.opens,
             "CLICKS": options.clicks,
             "OPTINS": options.optIns,
-            "OPTOUTS": options.optOuts
+            "OPTOUTS": options.optOuts,
+            "SEND_DATE_START": options.sendDateStart,
+            "SEND_DATE_END": options.sendDateEnd,
+            "EVENT_DATE_START": options.eventDateStart,
+            "EVENT_DATE_END": options.eventDateEnd,
         };
 
         if (typeof options.listId !== 'undefined') {
@@ -119,6 +143,24 @@ module.exports = {
         if (typeof options.optOuts !== 'undefined') {
             params["OPTOUTS"] = options.optOuts;
         }
+
+        if (typeof options.sendDateStart !== 'undefined') {
+            params["SEND_DATE_START"] = options.sendDateStart;
+        }
+
+        if (typeof options.sendDateEnd !== 'undefined') {
+            params["SEND_DATE_END"] = options.sendDateEnd;
+        }
+
+        if (typeof options.eventDateStart !== 'undefined') {
+            params["EVENT_DATE_START"] = options.eventDateStart;
+        }
+
+        if (typeof options.sendDateStart !== 'undefined') {
+            params["EVENT_DATE_END"] = options.eventDateEnd;
+        }
+
+
          return params;
      },
 

--- a/lib/xml-api/raw-recipient-data-export.js
+++ b/lib/xml-api/raw-recipient-data-export.js
@@ -69,7 +69,16 @@ module.exports = {
             assert: validator.assertBoolean,
             default: false
         },
-
+        sent: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false,
+        },
+        sentMailings: {
+            required: false,
+            assert: validator.assertBoolean,
+            default: false,
+        },
         optIns: {
             required: false,
             assert: validator.assertBoolean,
@@ -96,6 +105,8 @@ module.exports = {
             "ALL_EVENT_TYPES": options.allEventTypes,
             "OPENS": options.opens,
             "CLICKS": options.clicks,
+            "SENT": options.sent,
+            "SENT_MAILINGS": options.sentMailings,
             "OPTINS": options.optIns,
             "OPTOUTS": options.optOuts,
             "SEND_DATE_START": options.sendDateStart,
@@ -144,6 +155,14 @@ module.exports = {
             params["OPTOUTS"] = options.optOuts;
         }
 
+        if (typeof options.sent !== 'undefined' ) {
+            params["SENT"] = options.sent;
+        }
+
+        if (typeof options.sentMailings !== 'undefined') {
+            params["SENT_MAILINGS"] = options.sentMailings;
+        }
+
         if (typeof options.sendDateStart !== 'undefined') {
             params["SEND_DATE_START"] = options.sendDateStart;
         }
@@ -159,7 +178,6 @@ module.exports = {
         if (typeof options.sendDateStart !== 'undefined') {
             params["EVENT_DATE_END"] = options.eventDateEnd;
         }
-
 
          return params;
      },

--- a/lib/xml-api/update-recipient.js
+++ b/lib/xml-api/update-recipient.js
@@ -73,10 +73,10 @@ module.exports = {
     },
 
     generator: function(options) {
-
         var subnode, key;
 
         var params = {
+            "OLD_EMAIL": options.oldEmail,
             "LIST_ID": options.listId,
             "SEND_AUTOREPLY": options.sendAutoReply,
             "ALLOW_HTML": options.allowHtml
@@ -136,7 +136,6 @@ module.exports = {
 
             params["SNOOZE_SETTINGS"] = subnode;
         }
-
         return params;
     },
 
@@ -153,4 +152,3 @@ module.exports = {
         }
     }
 };
-


### PR DESCRIPTION
UpdateRecipient was [undocumented] in the brief docs included with the repo. It was missing a lookup based on an email address or recipient id for changes posted via the function to occur. Added the necessary fields in to make it work.

Wrote a new function (raw-recipient-data-export) to be able to handle an en masse export of a list with open and click counts per recipient. Not all fields available in the API are available in the function as of yet. 

I needed these to work for a work project, so I figured I'd make them happen. 
