### PR TITLE
Add contact list formatting

### DIFF
--- a/lib/xml-api/add-recipient.js
+++ b/lib/xml-api/add-recipient.js
@@ -88,6 +88,16 @@ module.exports = {
             }
             params["COLUMN"] = subnode;
         }
+
+        if (typeof options.contactLists !== 'undefined') {
+            subnode = [];
+            for (key in options.contactLists) {
+                subnode.push({
+                    CONTACT_LIST_ID: options.contactLists[key]
+                });
+            }
+            params["CONTACT_LISTS"] = subnode;
+          }
          return params;
      },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watson-campaign-automation-api",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Library for interacting with Watson Campaign Automation API",
   "main": "./lib/engage",
   "directories": {


### PR DESCRIPTION
Adds appropriate formatting for the child nodes inside `CONTACT_LISTS`. Should be `CONTACT_LIST_ID`, and are currently handled as an index-based array and do not function correctly.

Please see Issue 18 for more details.